### PR TITLE
Set number of cores in parallel execution to value defined in config.yaml

### DIFF
--- a/4_run_commands.sh
+++ b/4_run_commands.sh
@@ -3,7 +3,7 @@
 
 #set -euo pipefail
 
-cores=8
+cores="${CORES:-8}"
 instance_name="em-finemapping-big"
 
 python 3_make_commands.py | shuf | parallel -j $cores


### PR DESCRIPTION
Try to grab number of cores to be used for parallel execution from environment, otherwise use default value of 8.

Before, this variable was hard-coded to run on 8 cores, resulting in problems when running on my laptop. The `CORES` variable takes the setting from the `config.yaml` file and is passed into the Docker container through the `-e` parameter in the `run_finemapping` Snakemake rule.