### PR TITLE
Replace "yaml.load()" with "yaml.safe_load()" to avoid warnings.

### DIFF
--- a/1_scan_input_parquets.py
+++ b/1_scan_input_parquets.py
@@ -24,7 +24,7 @@ def main():
     # Load analysis config file
     config_file = 'configs/analysis.config.yaml'
     with open(config_file, 'r') as in_h:
-        config_dict = yaml.load(in_h)
+        config_dict = yaml.safe_load(in_h)
 
     # Make spark session
     spark = (

--- a/2_make_manifest.py
+++ b/2_make_manifest.py
@@ -16,7 +16,7 @@ def main():
     # Load analysis config file
     config_file = 'configs/analysis.config.yaml'
     with open(config_file, 'r') as in_h:
-        config_dict = yaml.load(in_h)
+        config_dict = yaml.safe_load(in_h)
 
     # Args
     input_pattern = os.path.join(config_dict['finemapping_output_dir'], 'tmp/filtered_input/*.json.gz')

--- a/3_make_commands.py
+++ b/3_make_commands.py
@@ -17,7 +17,7 @@ def main():
     # Load analysis config file
     config_file = 'configs/analysis.config.yaml'
     with open(config_file, 'r') as in_h:
-        config_dict = yaml.load(in_h)
+        config_dict = yaml.safe_load(in_h)
 
     # Args
     args = parse_args()

--- a/5_combine_results.py
+++ b/5_combine_results.py
@@ -23,7 +23,7 @@ def main():
     # Load analysis config file
     config_file = 'configs/analysis.config.yaml'
     with open(config_file, 'r') as in_h:
-        config_dict = yaml.load(in_h)
+        config_dict = yaml.safe_load(in_h)
 
     # Make spark session
     # Using `ignoreCorruptFiles` will skip empty files

--- a/finemapping/single_study.wrapper.py
+++ b/finemapping/single_study.wrapper.py
@@ -34,7 +34,7 @@ def main():
 
     # Load analysis config file
     with open(args.config_file, 'r') as in_h:
-        config_dict = yaml.load(in_h)
+        config_dict = yaml.safe_load(in_h)
     logger.info('Analysis config: \n' + pprint.pformat(config_dict, indent=2))
 
     # Run

--- a/partition_top_loci_by_chrom.py
+++ b/partition_top_loci_by_chrom.py
@@ -17,7 +17,7 @@ def main():
     # Load analysis config file
     config_file = 'configs/analysis.config.yaml'
     with open(config_file, 'r') as in_h:
-        config_dict = yaml.load(in_h)
+        config_dict = yaml.safe_load(in_h)
 
     # Args
     in_file = os.path.join(config_dict['finemapping_output_dir'], 'results/top_loci.json.gz')


### PR DESCRIPTION
Pretty simple, as title says: Replace `yaml.load()` with `yaml.safe_load()` to avoid warnings. Apparently, that is now the suggested way to load a YAML file.

See: <https://github.com/bioconda/bioconda-utils/issues/462#issuecomment-473584814>