### PR TITLE
created non-root user for finemapping docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
 FROM continuumio/miniconda:4.6.14
 
-# create non-root user
+# Create non-root user 
 RUN useradd -ms /bin/bash otg
-USER otg
 
-# Conda and the envirounment dependencies
-COPY ./environment.yaml /home/otg/finemapping/
-WORKDIR /home/otg/finemapping
-RUN conda env create -n finemapping --file environment.yaml
-RUN echo "source activate finemapping" > ~/.bashrc
-ENV PATH /home/otg/.conda/envs/finemapping/bin:$PATH
-
+# Do everything that requires root user
 # Install OpenJDK-8 (as root)
-USER root
 RUN apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     apt-get install -y ant && \
@@ -23,26 +15,33 @@ RUN apt-get update && \
     apt-get install ca-certificates-java && \
     apt-get clean && \
     update-ca-certificates -f;
+
+# Install parallel
+RUN apt install -yf parallel
+
+# download gcta
+RUN apt-get install unzip
+RUN wget https://cnsgenomics.com/software/gcta/bin/gcta_1.92.3beta3.zip -P /software/gcta
+RUN chown -R otg:otg /software/gcta
+
+# switch to otg user
 USER otg
+
+# Conda and the envirounment dependencies
+COPY ./environment.yaml /home/otg/finemapping/
+WORKDIR /home/otg/finemapping
+RUN conda env create -n finemapping --file environment.yaml
+RUN echo "source activate finemapping" > ~/.bashrc
+ENV PATH /home/otg/.conda/envs/finemapping/bin:$PATH
 
 # Setup JAVA_HOME -- useful for docker commandline
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 RUN export JAVA_HOME
 
 # Install GCTA
-USER root
-RUN apt-get install unzip
-RUN wget https://cnsgenomics.com/software/gcta/bin/gcta_1.92.3beta3.zip -P /software/gcta
-RUN chown -R otg:otg /software/gcta
-USER otg
 RUN unzip /software/gcta/gcta_1.92.3beta3.zip -d /software/gcta
 RUN rm /software/gcta/gcta_1.92.3beta3.zip
 ENV PATH="/software/gcta/gcta_1.92.3beta3:${PATH}"
-
-# Install parallel
-USER root
-RUN apt install -yf parallel
-USER otg
 
 # Google Cloud SDK
 RUN curl https://sdk.cloud.google.com | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM continuumio/miniconda:4.6.14
 
 # Create non-root user 
-RUN useradd -ms /bin/bash otg
+ARG UID
+ARG GID
+RUN groupadd -g $GID -o otg
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash
 
 # Do everything that requires root user
 # Install OpenJDK-8 (as root)
@@ -54,6 +57,7 @@ COPY ./ /home/otg/finemapping
 
 # Make all files in finemapping owned by the non-root user
 USER root
+RUN mkdir /home/otg/finemapping/configs
 RUN chown -R otg:otg /home/otg/finemapping
 
 # Run container as non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM continuumio/miniconda:4.6.14
 
 # create non-root user
-RUN useradd -ms /bin/bash my-user
-USER my-user
+RUN useradd -ms /bin/bash otg
+USER otg
 
 # Conda and the envirounment dependencies
-COPY ./environment.yaml /home/my-user/finemapping/
-WORKDIR /home/my-user/finemapping
+COPY ./environment.yaml /home/otg/finemapping/
+WORKDIR /home/otg/finemapping
 RUN conda env create -n finemapping --file environment.yaml
 RUN echo "source activate finemapping" > ~/.bashrc
-ENV PATH /home/my-user/.conda/envs/finemapping/bin:$PATH
+ENV PATH /home/otg/.conda/envs/finemapping/bin:$PATH
 
 # Install OpenJDK-8 (as root)
 USER root
@@ -23,7 +23,7 @@ RUN apt-get update && \
     apt-get install ca-certificates-java && \
     apt-get clean && \
     update-ca-certificates -f;
-USER my-user
+USER otg
 
 # Setup JAVA_HOME -- useful for docker commandline
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
@@ -33,8 +33,8 @@ RUN export JAVA_HOME
 USER root
 RUN apt-get install unzip
 RUN wget https://cnsgenomics.com/software/gcta/bin/gcta_1.92.3beta3.zip -P /software/gcta
-RUN chown -R my-user:my-user /software/gcta
-USER my-user
+RUN chown -R otg:otg /software/gcta
+USER otg
 RUN unzip /software/gcta/gcta_1.92.3beta3.zip -d /software/gcta
 RUN rm /software/gcta/gcta_1.92.3beta3.zip
 ENV PATH="/software/gcta/gcta_1.92.3beta3:${PATH}"
@@ -42,7 +42,7 @@ ENV PATH="/software/gcta/gcta_1.92.3beta3:${PATH}"
 # Install parallel
 USER root
 RUN apt install -yf parallel
-USER my-user
+USER otg
 
 # Google Cloud SDK
 RUN curl https://sdk.cloud.google.com | bash
@@ -51,11 +51,11 @@ RUN curl https://sdk.cloud.google.com | bash
 CMD ["/bin/bash"]
 
 # Copy the v2d project
-COPY ./ /home/my-user/finemapping
+COPY ./ /home/otg/finemapping
 
 # Make all files in finemapping owned by the non-root user
 USER root
-RUN chown -R my-user:my-user /home/my-user/finemapping
+RUN chown -R otg:otg /home/otg/finemapping
 
 # Run container as non-root user
-USER my-use
+USER otg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,48 @@
 FROM continuumio/miniconda:4.6.14
 
+# create non-root user
+RUN useradd -ms /bin/bash my-user
+USER my-user
+
 # Conda and the envirounment dependencies
-COPY ./environment.yaml /finemapping/
-WORKDIR /finemapping
+COPY ./environment.yaml /home/my-user/finemapping/
+WORKDIR /home/my-user/finemapping
 RUN conda env create -n finemapping --file environment.yaml
 RUN echo "source activate finemapping" > ~/.bashrc
-ENV PATH /opt/conda/envs/finemapping/bin:$PATH
+ENV PATH /home/my-user/.conda/envs/finemapping/bin:$PATH
 
-# Install OpenJDK-8
+# Install OpenJDK-8 (as root)
+USER root
 RUN apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     apt-get install -y ant && \
     apt-get clean;
 
-# Fix certificate issues
+# Fix certificate issues (as root)
 RUN apt-get update && \
     apt-get install ca-certificates-java && \
     apt-get clean && \
     update-ca-certificates -f;
+USER my-user
 
 # Setup JAVA_HOME -- useful for docker commandline
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 RUN export JAVA_HOME
 
 # Install GCTA
+USER root
 RUN apt-get install unzip
 RUN wget https://cnsgenomics.com/software/gcta/bin/gcta_1.92.3beta3.zip -P /software/gcta
+RUN chown -R my-user:my-user /software/gcta
+USER my-user
 RUN unzip /software/gcta/gcta_1.92.3beta3.zip -d /software/gcta
 RUN rm /software/gcta/gcta_1.92.3beta3.zip
 ENV PATH="/software/gcta/gcta_1.92.3beta3:${PATH}"
 
+# Install parallel
+USER root
 RUN apt install -yf parallel
+USER my-user
 
 # Google Cloud SDK
 RUN curl https://sdk.cloud.google.com | bash
@@ -39,4 +51,11 @@ RUN curl https://sdk.cloud.google.com | bash
 CMD ["/bin/bash"]
 
 # Copy the v2d project
-COPY ./ /finemapping
+COPY ./ /home/my-user/finemapping
+
+# Make all files in finemapping owned by the non-root user
+USER root
+RUN chown -R my-user:my-user /home/my-user/finemapping
+
+# Run container as non-root user
+USER my-use


### PR DESCRIPTION
this fixes the docker-snakemake permission issue for rule: run finemapping in otg-data-loading...

**note that after this pull request is accepted, the finemapping config file: finemapping.yaml in otg-data-loading should be changed!**
finmapping folder in input locations and output locations paths should be changed from:
`/finemapping/`
to
`/home/my-user/finemapping/`